### PR TITLE
Python 3 compat, requests Exception handling and other goodies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ docs/_build/
 
 # git
 .git
+
+# IDEs
+/.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+chikka/test_vars.py
 
 # Translations
 *.mo

--- a/README.md
+++ b/README.md
@@ -18,5 +18,12 @@ be generated.
 
     c.send('09991234567', 'Mensahe mo na may message id', message_id='1234567890')
 
+## Testing ##
 
+Unit tested for:
+
+* Python 2.7
+* Python 3.3
+* Python 3.4
+* Python 3.5
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,20 @@
-INSTALLATION
-============
 
-$ pip install python-chikka
+# Python Chikka #
 
+## INSTALLATION ##
 
-USAGE
-======
+    $ pip install python-chikka
 
-from chikka import Chikka
+## USAGE ##
 
-c = Chikka(client_id=CLIENT_ID, secret_key=SECRET_KEY, shortcode=SHORTCODE)
+    from chikka import Chikka
 
-c.send('09991234567', 'Mensahe mo')
+    c = Chikka(client_id=CLIENT_ID, secret_key=SECRET_KEY, shortcode=SHORTCODE)
+    c.send('09991234567', 'Mensahe mo')
 
-
-Before sending your message you can define a message_id
+Before sending your message you may  define a message_id
 if you do not supply a message_id a random message_id will
-be generated 
+be generated.
 
 c.send('09991234567', 'Mensahe mo na may message id', message_id='1234567890')
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Before sending your message you may  define a message_id
 if you do not supply a message_id a random message_id will
 be generated.
 
-c.send('09991234567', 'Mensahe mo na may message id', message_id='1234567890')
+    c.send('09991234567', 'Mensahe mo na may message id', message_id='1234567890')
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 
 # Python Chikka #
 
-## INSTALLATION ##
+## Installation ##
 
     $ pip install python-chikka
 
-## USAGE ##
+## Usage ##
 
     from chikka import Chikka
 

--- a/chikka/__init__.py
+++ b/chikka/__init__.py
@@ -13,4 +13,7 @@ __author_email__ = "mark.meriales@gmail.com"
 __app_url__ = "https://github.com/makmac213/python-chikka/"
 __download_url__ = "https://github.com/makmac213/python-chikka/"
 
-from core import *
+from .core import *
+from .exceptions import *
+from .payload import *
+from .test import *

--- a/chikka/__init__.py
+++ b/chikka/__init__.py
@@ -5,7 +5,7 @@
 """
 
 
-__version__ = "0.5"
+__version__ = "0.5.1"
 __app_name__ = "python-chikka"
 __description__ = "Python API Wrapper for Chikka "
 __author__ = "Mark Allan B Meriales"

--- a/chikka/core.py
+++ b/chikka/core.py
@@ -1,7 +1,8 @@
 import os
-import re
+import binascii
 import requests
 from .exceptions import *
+from .payload import *
 
 # add local_settings.py to .gitignore
 # variables in local_settings optional, it won't be uploaded
@@ -21,74 +22,49 @@ class Chikka(object):
         self.secret_key = secret_key
         self.shortcode = shortcode
 
-    def send(self, mobile_number, message, message_id=None, **kwargs):
+    def send(
+            self, mobile_number, message, message_id=None,
+            request_id=None, request_cost=None):
         payload = self._prepare_payload()
+        payload.mobile_number = mobile_number
+        payload.request_id = request_id
 
-        # check and validate mobile number
-        if not mobile_number:
-            raise NullMobileNumberException
-        else:
-            mobile_number = str(mobile_number)
-
-        # e.g. 09991234567
-        if len(mobile_number) == 11 and mobile_number.startswith('0'):
-            mobile_number = '%s%s' % ('63', mobile_number[1:])
-
-        # e.g. 639991234567
-        if not re.match('^63[0-9]{10}', mobile_number):
-            raise InvalidMobileNumberException
-
-        payload['mobile_number'] = mobile_number
-
-        # check if request_id was passed to this method
-        # means a message was received
-        # determines message_type, adds other required payload
-        if kwargs.get('request_id') is not None:
-            payload['request_id'] = kwargs.get('request_id')
-
-            # if message type is REPLY user is required to supply
+        # check if `request_id` was passed
+        # which means a message was received
+        # and determines `message_type` and `request_cost`
+        if request_id:
+            payload.message_type = 'REPLY'
+            # since message type is REPLY user is required to supply
             # the request cost
-            request_cost = kwargs.get('request_cost')
-            if request_cost is not None:
-                payload['request_cost'] = request_cost
+            if request_cost:
+                payload.request_cost = request_cost
             else:
                 raise NullRequestCostException
-
-            payload['message_type'] = 'REPLY'
         else:
-            payload['message_type'] = 'SEND'
+            payload.message_type = 'SEND'
 
-        # message_id can be passed to this method
+        # `message_id` can be passed to this method
         # this can be useful to track messages sent
-        # however if message_id does not exist this method
-        # will generate a random message id
-        payload['message_id'] = kwargs.get(
-            'message_id', os.urandom(16).encode('hex'))
+        # however if `message_id` was not provided
+        # we will generate a random `message_id`
+        payload.message_id = message_id or binascii.hexlify(os.urandom(16))
 
-        payload['message'] = message
+        payload.message = message
+        payload.response = requests.post(API_URL, data=payload.dict())
 
-        post_response = requests.post(API_URL, data=payload)
+        return payload
 
-        return payload, post_response
-
-    def _prepare_payload(self):
+    def _prepare_payload(self, *args, **kwargs):
 
         client_id = getattr(self, 'client_id', CLIENT_ID)
         secret_key = getattr(self, 'secret_key', SECRET_KEY)
         shortcode = getattr(self, 'shortcode', SHORTCODE)
 
         if not client_id:
-            print "Error: Your Client ID is required.\n"
-            raise NullClientIDException
+            raise NullClientIDException("Error: Your Client ID is required.")
         if not secret_key:
-            print "Error: Your Secret Key is required.\n"
-            raise NullSecretKeyException
+            raise NullSecretKeyException("Error: Your Secret Key is required.")
         if not shortcode:
-            print "Error: Your shortcode is required.\n"
-            raise NullShortCodeException
+            raise NullShortCodeException("Error: Your shortcode is required.")
 
-        return {
-            'client_id': client_id,
-            'secret_key': secret_key,
-            'shortcode': shortcode,
-        }
+        return ChikkaPayload(client_id, secret_key, shortcode, *args, **kwargs)

--- a/chikka/core.py
+++ b/chikka/core.py
@@ -16,6 +16,7 @@ API_URL = 'https://post.chikka.com/smsapi/request'
 class Chikka(object):
 
     def __init__(self, *args, **kwargs):
+        # TODO this can be written in a better way
         for k, v in kwargs.iteritems():
             setattr(self, k, v)
 

--- a/chikka/exceptions.py
+++ b/chikka/exceptions.py
@@ -1,18 +1,22 @@
-
 class NullMobileNumberException(Exception):
     pass
+
 
 class InvalidMobileNumberException(Exception):
     pass
 
+
 class NullClientIDException(Exception):
     pass
+
 
 class NullSecretKeyException(Exception):
     pass
 
+
 class NullShortCodeException(Exception):
     pass
+
 
 class NullRequestCostException(Exception):
     pass

--- a/chikka/exceptions.py
+++ b/chikka/exceptions.py
@@ -20,3 +20,74 @@ class NullShortCodeException(Exception):
 
 class NullRequestCostException(Exception):
     pass
+
+
+class MessageIdTooLong(Exception):
+    pass
+
+
+# Excemption According to
+# https://api.chikka.com/docs/handling-messages#send-sms
+class RequestError(Exception):
+    pass
+
+
+class BadRequest(RequestError):
+    pass
+
+
+class MissingRequiredFields(BadRequest):
+    pass
+
+
+class InvalidMessageID(BadRequest):
+    pass
+
+
+class MessageBodyTooLong(BadRequest):
+    pass
+
+
+class InsufficientTrialCredits(BadRequest):
+    pass
+
+
+class InsufficientCredits(BadRequest):
+    pass
+
+
+class InvalidUsedRequestID(BadRequest):
+    pass
+
+
+class InactiveInvalidAccessCode(BadRequest):
+    pass
+
+
+class InvalidMessageType(BadRequest):
+    pass
+
+
+class InvalidMobileNumberError(BadRequest, InvalidMobileNumberException):
+    # From experience of passing an invalid number to the chikka API
+    pass
+
+
+class Unauthorized(RequestError):
+    pass
+
+
+class MethodNotAllowed(RequestError):
+    pass
+
+
+class NotFound(RequestError):
+    pass
+
+
+class ServerError(RequestError):
+    pass
+
+
+class UnknownResponseError(Exception):
+    pass

--- a/chikka/payload.py
+++ b/chikka/payload.py
@@ -1,0 +1,143 @@
+import re
+from requests import Response
+import six
+from .exceptions import *
+
+try:
+    # noinspection PyUnresolvedReferences,PyPackageRequirements
+    from phonenumbers import PhoneNumber, PhoneNumberFormat, format_number, is_valid_number
+except ImportError:
+    PhoneNumber = None
+
+BAD_REQUEST_DESCRIPTIONS = [
+    # Reference: https://api.chikka.com/docs/handling-messages#send-sms
+    (re.compile(r"^Missing Required Fields"), MissingRequiredFields),
+    (re.compile(r"^Invalid Message ID"), InvalidMessageID),
+    (re.compile(r"^Message Body Exceeded Allowed Length"), MessageBodyTooLong),
+    (re.compile(r"^Insufficient Trial Credits"), InsufficientTrialCredits),
+    (re.compile(r"^Insufficient Credits"), InsufficientCredits),
+    (re.compile(r"^Invalid.Used Request ID"), InvalidUsedRequestID),
+    (re.compile(r"^Inactive.Invalid Access code"), InactiveInvalidAccessCode),
+    (re.compile(r"^Invalid Message Type"), InvalidMessageType),
+    # From testing, not found in documents.
+    (re.compile(r"^Invalid Mobile Number"), InvalidMobileNumberError)
+]
+NON_NUMERIC = re.compile("\D+")
+
+
+class ChikkaPayload(object):
+    def __init__(
+            self, client_id, secret_key, shortcode,
+            mobile_number=None, message=None,
+            request_id=None, message_id=None,
+            message_type=None, request_cost=None):
+        # PRELUDE
+        self.__mobile_number = None
+        self.__response = None
+        # PROCESS
+        self.client_id = client_id
+        self.secret_key = secret_key
+        self.shortcode = shortcode
+        self.message = message
+        self.request_id = request_id
+        self.message_id = message_id
+        self.message_type = message_type
+        self.request_cost = request_cost
+        if mobile_number:
+            self.mobile_number = mobile_number
+
+    @property
+    def mobile_number(self):
+        return self.__mobile_number
+
+    @mobile_number.setter
+    def mobile_number(self, mobile_number):
+        # HANDLE
+        # check and validate mobile number
+        if not mobile_number:
+            raise NullMobileNumberException
+        if PhoneNumber and isinstance(mobile_number, PhoneNumber):
+            if not is_valid_number(mobile_number):
+                raise InvalidMobileNumberException(mobile_number)
+            mobile_str = format_number(mobile_number, PhoneNumberFormat.E164)
+        else:
+            mobile_str = six.text_type(mobile_number)
+        # Remove all non-numeric
+        mobile_str = NON_NUMERIC.sub("", mobile_str)
+        # e.g. 09991234567
+        if len(mobile_str) == 11 and mobile_str.startswith('0'):
+            mobile_str = "{}{}".format('63', mobile_str[1:])
+        # e.g. 639991234567
+        if not re.match('^63[0-9]{10}', mobile_str):
+            raise InvalidMobileNumberException(mobile_str)
+        # CONCLUDE
+        self.__mobile_number = mobile_str
+
+    @mobile_number.deleter
+    def mobile_number(self):
+        del self.__mobile_number
+
+    @property
+    def response(self):
+        return self.__response
+
+    @response.setter
+    def response(self, value):
+        # HANDLE
+        assert isinstance(value, Response), "value needs to a subclass of requests.Response"
+        # PREPARE
+        chikka_json = value.json()
+        status, message = chikka_json['status'], chikka_json['message']
+        description = chikka_json.get('description', "")
+        # PROCESS
+        if status == 200:
+            self.__response = value
+        elif status == 400:
+            for description_re, exp_cls in BAD_REQUEST_DESCRIPTIONS:
+                if description_re.match(description):
+                    raise exp_cls(description)
+            raise UnknownResponseError(chikka_json)
+        elif status == 401:
+            raise Unauthorized
+        elif status == 403:
+            raise MethodNotAllowed
+        elif status == 404:
+            raise NotFound
+        elif status == 500:
+            raise ServerError
+        else:
+            raise UnknownResponseError(chikka_json)
+
+    @response.deleter
+    def response(self):
+        del self.__response
+
+    def __getitem__(self, item):
+        try:
+            return getattr(self, item)
+        # Note:  This is for backwards compatibility for users of the 0.5.0
+        # who expects a `dict` instead of an object
+        # For deprecation
+        except AttributeError as exc:
+            raise TypeError(exc.message)
+
+    def __setitem__(self, key, value):
+        setattr(self, key, value)
+
+    def __delitem__(self, key):
+        delattr(self, key)
+
+    def dict(self):
+        return {
+            k: v for k, v in
+            (
+                ('client_id', self.client_id),
+                ('secret_key', self.secret_key),
+                ('shortcode', self.shortcode),
+                ('mobile_number', self.mobile_number),
+                ('message', self.message),
+                ('request_id', self.request_id),
+                ('message_id', self.message_id),
+                ('message_type', self.message_type),
+                ('request_cost', self.request_cost)
+            ) if v}

--- a/chikka/test.py
+++ b/chikka/test.py
@@ -1,0 +1,86 @@
+# coding=utf-8
+#
+# To run, preferably:
+# $ python2.7 -m unittest discover
+#
+from unittest import TestCase, main
+from logging import getLogger
+from .core import *
+from .payload import *
+from .exceptions import *
+
+try:
+    from .test_vars import *
+except ImportError:
+    raise ImportError(
+        "Create a file named `test_vars.py` in the same directory, and assign: "
+        "CLIENT_ID, SECRET_KEY, SHORTCODE and MOBILES.")
+else:
+    assert isinstance(MOBILES, list), "MOBILES needs to be as list of valid mobile numbers."
+    assert len(MOBILES), "MOBILES must have at least 1 valid mobile number."
+
+try:
+    # noinspection PyUnresolvedReferences,PyPackageRequirements
+    from phonenumbers import PhoneNumber, PhoneNumberFormat, format_number
+except ImportError:
+    PhoneNumber = None
+
+log = getLogger(__name__)
+
+
+class TestChikka(TestCase):
+    @classmethod
+    def set_test_variables(cls):
+        cls.client_id = CLIENT_ID
+        assert cls.client_id
+        cls.secret_key = SECRET_KEY
+        assert cls.secret_key
+        cls.short_code = SHORTCODE
+        assert cls.short_code
+        cls.valid_mobiles = MOBILES
+        cls.invalid_mobiles = [
+            "009279517459",
+            "+551155256325"]
+        cls.chikka_instance = Chikka(cls.client_id, cls.secret_key, cls.short_code)
+
+    def test_chikka_instance(self):
+        self.assertIsInstance(self.chikka_instance, Chikka)
+
+    def test_basic_message(self):
+        message = "@test_basic_message {}"
+        for mobile in self.valid_mobiles:
+            chikka_response = self.chikka_instance.send(mobile, message.format(mobile))
+            self.assertIsInstance(chikka_response, ChikkaPayload)
+            self.assertIsInstance(chikka_response.response, Response)
+            self.assertTrue(chikka_response['client_id'], "Not a `dict()` like instance.")
+
+    def test_invalid_mobile(self):
+        message = "@test_invalid_mobile"
+        for mobile in self.invalid_mobiles:
+            try:
+                chikka_response = self.chikka_instance.send(mobile, message)
+            except InvalidMobileNumberException:
+                pass
+            except Exception as exc:
+                self.fail("`{}` type of error was raised for `{}`".format(exc, mobile))
+            else:
+                self.fail([
+                    "`{}` was seen as valid.".format(mobile),
+                    {
+                        'dict': chikka_response.dict(),
+                        'json': chikka_response.response.json()
+                    }])
+
+    def test_unicode_message(self):
+        message = "@test_unicode_message Hello βeta, Niño."
+        self.chikka_instance.send(self.valid_mobiles[0], message)
+
+    def test_too_long_message(self):
+        message = "Some Test." * 60
+        try:
+            self.chikka_instance.send(self.valid_mobiles[0], message)
+        except Exception as exc:
+            self.assertIsInstance(exc, MessageBodyTooLong)
+
+
+TestChikka.set_test_variables()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests>=2.0.1
+six
+phonenumbers

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,10 @@ setup(
     author="Mark Allan B Meriales",
     author_email="mark.meriales@gmail.com",
     packages=['chikka'],
-    install_requires=['requests>=2.0.1'],
+    install_requires=['requests>=2.0.1', 'six'],
+    extras_require={
+        'phonenumbers': ['phonenumbers']
+    },
     url="https://github.com/makmac213/python-chikka/",
     classifiers=(
         'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,17 @@
-import chikka
-
 try:
     from setuptools import setup
 except ImportError:
     from distutils.core import setup
 
 setup(
-    name=chikka.__app_name__,
-    version=chikka.__version__,
-    description=chikka.__description__,
-    author=chikka.__author__,
-    author_email=chikka.__author_email__,
+    name="python-chikka",
+    version="0.5.1",
+    description="Python API Wrapper for Chikka ",
+    author="Mark Allan B Meriales",
+    author_email="mark.meriales@gmail.com",
     packages=['chikka'],
     install_requires=['requests>=2.0.1'],
-    url=chikka.__app_url__,
+    url="https://github.com/makmac213/python-chikka/",
     classifiers=(
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
@@ -21,5 +19,5 @@ setup(
         'Programming Language :: Python',
         'License :: Freeware',
     ),
-    download_url=chikka.__download_url__,
+    download_url="https://github.com/makmac213/python-chikka/",
 )

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     author=chikka.__author__,
     author_email=chikka.__author_email__,
     packages=['chikka'],
-    install_requires=['requests==2.0.1'],
+    install_requires=['requests>=2.0.1'],
     url=chikka.__app_url__,
     classifiers=(
         'Development Status :: 4 - Beta',

--- a/test_vars.py
+++ b/test_vars.py
@@ -1,0 +1,18 @@
+# Sample test_var, copy this and create your own at `chikka` directory.
+
+CLIENT_ID = "CLIENT_ID"
+SECRET_KEY = "SECRET_KEY"
+SHORTCODE = "SHORTCODE"
+MOBILES = [
+    # Preferably a number you own.
+    "091812345678",
+    "+63 919 123 4567",
+]
+
+try:
+    # noinspection PyUnresolvedReferences,PyPackageRequirements
+    from phonenumbers import parse
+except ImportError:
+    pass
+else:
+    MOBILES += [parse(_, region="PH") for _ in MOBILES]


### PR DESCRIPTION
- Verbose-ify `Chikka.__init__`'s arguments, from the old generic kwarg loop
- Added `message_id` to `Chikka.send()` arguments
- Removed the exemptions at the bottom
- Removes `import` statement from `setup.py` because it throws an exception if `requests` package is not installed.  Bad for `virtualenv`
- Redeveloped the chikka package
- Now portable for Python 3
- Added `six` to python dependency for cross Python version compatibility
- Returned values of Chikka.send() is now an instance of ChikkaPayload but retains its old `dict` behavior
- Added `test.py` file for unittesting.
- Took advantage of @property setter and getter to refactor the validation scripts away from core.py
- Expanded the Exception classes to include Errors returned by the Chikka API
- Added compatibility for `phonenumbers`, although only optional
- Chkka's POST Response (as wrapped by `requests` lib) is now included in the returned payload of `.send()`
- Proper exemptions are now raised whenever applicable, especially if it is from the Chikka API like 400 BAD REQUESTS
